### PR TITLE
Development of the packet_loss_counter module and its tesbench

### DIFF
--- a/src/packet_loss_counter.v
+++ b/src/packet_loss_counter.v
@@ -1,0 +1,75 @@
+
+module packet_loss_counter (
+    input  clk,
+    input  reset_n,
+    input  valid,
+    input  sync,
+    input  en_reset_counter,
+    input  [7:0] ts_data,
+    output [7:0] error_count
+);
+    localparam IDLE         = 0,
+               COUNT        = 1,
+               PROCESSING   = 2;
+
+    reg [1:0] state;
+    reg [1:0] byte_counter;
+    reg [1:0] adaption_field_ctrl;
+    reg [3:0] previous_cc;          // previous continuity counter (cc)
+    reg [3:0] current_cc;           // current cc
+    reg firt_cc_flag;               // flag to indicate first cc
+
+    // output reg
+    reg [7:0] error_count_;
+    assign error_count = error_count_;
+
+    always @(posedge clk, negedge reset_n, posedge en_reset_counter) begin
+        if (!reset_n || en_reset_counter) begin
+            state <= 0;
+            byte_counter <= 0;
+            adaption_field_ctrl <= 0;
+            previous_cc <= 0;
+            current_cc <= 0;
+            firt_cc_flag <= 1;
+            error_count_ <= 0;
+        end else if (valid) begin
+            case (state)
+                IDLE: begin
+                    if (sync) begin
+                        state <= COUNT;
+                        byte_counter <= 0;
+                    end
+                end
+                COUNT: begin
+                    if (byte_counter == 2) begin
+                        current_cc <= ts_data[3:0];
+                        adaption_field_ctrl <= ts_data[5:4];
+                        byte_counter <= 0;
+                        state <= PROCESSING;
+                    end else begin
+                        byte_counter <= byte_counter + 1;
+                    end
+                end
+                PROCESSING: begin
+                    // The continuity_counter shall not be incremented when 
+                    // the adaptation_field_control of the packet equals '00' or '10'
+                    if ((adaption_field_ctrl == 2'b00) || (adaption_field_ctrl == 2'b10)) begin
+                        byte_counter <= 0;
+                    end else if (!firt_cc_flag) begin
+                        if (current_cc == previous_cc + 1) begin
+                            byte_counter <= 0;
+                        end else begin 
+                            error_count_ = error_count_ + 1;
+                        end
+                        previous_cc <= current_cc;
+                    end else begin
+                        previous_cc <= current_cc;
+                        firt_cc_flag <= 0;
+                    end
+                    state <= IDLE;
+                end
+                default: state <= IDLE;
+            endcase
+        end
+    end
+endmodule

--- a/tb/packet_loss_counter_tb.v
+++ b/tb/packet_loss_counter_tb.v
@@ -1,0 +1,90 @@
+`timescale 1ns/1ps
+
+module packet_loss_counter_tb ();
+    localparam FILE_NAME1 = "tsdata1_loss.ts";
+    localparam FILE_NAME2 = "tsdata2_loss.ts";
+    localparam FILE_NAME3 = "tsdata3_loss.ts";
+    localparam FILE_NAME4 = "tsdata4_loss.ts";
+    localparam DATA_WIDTH = 8;
+
+    reg  clk;
+    reg  reset_n;
+    reg  valid;
+    reg  sync;
+    reg  [7:0] ts_data;
+    reg  en_reset_counter;
+    wire [7:0] error_count;
+
+
+    wire [DATA_WIDTH-1:0] byte_data1;
+    wire [DATA_WIDTH-1:0] byte_data2;
+    wire [DATA_WIDTH-1:0] byte_data3;
+    wire [DATA_WIDTH-1:0] byte_data4;
+
+    stimulus_from_file # (
+        .FILE_NAME1(FILE_NAME1),
+        .FILE_NAME2(FILE_NAME2),
+        .FILE_NAME3(FILE_NAME3),
+        .FILE_NAME4(FILE_NAME4),
+        .DATA_WIDTH(DATA_WIDTH)
+    )
+    stimulus_from_file_inst (
+        .clk(clk),
+        .byte_data1(byte_data1),
+        .byte_data2(byte_data2),
+        .byte_data3(byte_data3),
+        .byte_data4(byte_data4)
+    );
+
+    packet_loss_counter  uut (
+        .clk(clk),
+        .reset_n(reset_n),
+        .valid(valid),
+        .sync(sync),
+        .en_reset_counter(en_reset_counter),
+        .ts_data(ts_data),
+        .error_count(error_count)
+    );
+
+    initial begin
+        clk = 1;
+        forever #5 clk = ~clk;
+    end
+
+    initial begin
+        en_reset_counter = 1'b0;
+        valid = 1'b0;
+        sync = 1'b0;
+        reset_n = 1'b0; #40;
+        reset_n = 1'b1;
+
+        repeat(4700) begin
+            @(posedge clk)
+            if (byte_data1 == 8'h47) begin
+                sync = 1'b1;
+                valid = 1'b1;
+                ts_data = byte_data1;
+            end else begin
+                sync = 1'b0;
+                valid = 1'b1;
+                ts_data = byte_data1;
+            end
+        end
+
+        // testing the main control reset counter signal
+        en_reset_counter = 1'b1; #10;
+        en_reset_counter = 1'b0;
+        repeat(94000) begin
+            @(posedge clk)
+            if (byte_data1 == 8'h47) begin
+                sync = 1'b1;
+                valid = 1'b1;
+                ts_data = byte_data1;
+            end else begin
+                sync = 1'b0;
+                valid = 1'b1;
+                ts_data = byte_data1;
+            end
+        end
+    end
+endmodule


### PR DESCRIPTION
## [Marcos-002] Development of the packet_loss_counter module and its tesbench
### Description:
* Module that receives a transport stream (TS) data byte by byte and, when it receives the beginning of a packet indicated by its valid and sync signals, verifies the fields of the continuity counter and adaptation field control to check for packet loss and updates the packet loss counter in the output.

### Added files:
* `src/packet_loss_counter.v`
* `tb/packet_loss_counter_tb.v`